### PR TITLE
fix: align CI job names with branch protection checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm test -- --coverage
-      - run: npx eslint src/ index.js functions.js __tests__/
       - name: Security audit
         run: npm audit --audit-level=moderate || true
       - name: Upload coverage
@@ -27,7 +26,18 @@ jobs:
           name: coverage
           path: coverage/
 
-  bazel:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx eslint src/ index.js functions.js __tests__/
+
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +51,7 @@ jobs:
 
   sbom:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, lint]
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
@@ -64,7 +74,7 @@ jobs:
 
   provenance:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, lint]
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Split monolithic `test` job into three separate jobs matching branch protection required status checks:
  - **`test`**: npm test + coverage + security audit
  - **`lint`**: eslint (extracted from test job)
  - **`ci`**: bazel build + test (renamed from `bazel`)
- Updated `sbom` and `provenance` to depend on both `test` and `lint`

## Context
Branch protection requires status checks named `ci`, `lint`, `test` to pass before merge. Previously, only `test` existed as a job name — `lint` ran as a step inside `test` (invisible to GitHub checks) and `bazel` didn't match any required check name. This meant PRs could never satisfy all three required checks.

## Test plan
- [ ] Verify the `ci`, `lint`, and `test` checks all appear on this PR
- [ ] Confirm all three pass (or fail with real issues, not missing checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)