### PR TITLE
docs: fix dashboard description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,15 @@ repository in your GitHub organization.
 
 ## Dashboard
 
-Temper ships with a real-time operations dashboard powered by **thrum** — a Rust/Axum
-backend with HTMX and SSE for live agent monitoring. The dashboard provides:
+Temper includes a built-in operations dashboard for monitoring compliance and
+activity across your organization. The dashboard provides:
 
-- Task queue with approve/reject/retry actions
-- Live agent activity grid with streaming stdout/stderr
-- Per-task review pages with syntax-colored diffs and gate reports
-- Budget tracking, memory inspection, and agent-to-agent messaging
+- Organization-wide compliance score with per-repo breakdown
+- Repository health cards — branch protection, signed commits, CI status, merge settings, labels
+- Active pull request tracker with check status, labels, and age
+- Signal feed for real-time webhook events and configuration drift
 
-Run `thrum` alongside the Probot app, or access the dashboard at `/dashboard` when
-deployed with the standalone HTTP handler.
+Access the dashboard at `/dashboard` when running with the standalone HTTP handler.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Remove incorrect thrum attribution from the Dashboard section — the dashboard is built into Temper itself via `src/dashboard.js`
- Update feature list to match actual dashboard capabilities visible in the hero screenshot (compliance score, health cards, PR tracker, signals)

## Context
The previous commit (`cc94a63`) incorrectly described the dashboard as "powered by thrum". This corrects that.

## Test plan
- [ ] Verify README renders correctly on GitHub with the hero screenshot
- [ ] Confirm dashboard description matches the screenshot


🤖 Generated with [Claude Code](https://claude.com/claude-code)