### PR TITLE
fix: require PR reviews and enforce admin protection

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -31,8 +31,11 @@ branch_protection:
     required_status_checks:
       strict: true
       contexts: []
-    enforce_admins: false
-    required_pull_request_reviews: null
+    enforce_admins: true
+    required_pull_request_reviews:
+      required_approving_review_count: 1
+      dismiss_stale_reviews: true
+      require_code_owner_reviews: false
     required_linear_history: false
     required_conversation_resolution: false
     restrictions: null


### PR DESCRIPTION
## Summary

- Changes `required_pull_request_reviews` from `null` to require 1 approving review with stale review dismissal
- Enables `enforce_admins: true` so admins cannot bypass protection rules
- Fixes the gap where direct pushes to `main` were allowed despite branch protection showing as active

## Root cause

`config.yml` had `required_pull_request_reviews: null`, which tells GitHub to **not** require PR reviews. Other protections (signed commits, status checks, no force push) were active — so the dashboard correctly showed "protected" — but the specific gate that blocks direct pushes was disabled.

## Impact

After Temper applies this config, all 26 monitored repos will require:
- At least 1 approving review before merge
- Stale reviews dismissed on new pushes
- Admin compliance (no admin bypass)

## Test plan

- [ ] Merge this PR
- [ ] Run `/sync-all-repos` or wait for Temper to apply the config
- [ ] Verify direct push to `main` is rejected on any repo
- [ ] Verify PR workflow works (create PR → approve → merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)