### PR TITLE
feat: AI Reviews tab — stats banner + compact table + detail drawers

### DIFF
--- a/__tests__/integration/ai-review.test.js
+++ b/__tests__/integration/ai-review.test.js
@@ -1703,16 +1703,18 @@ describe('ai-review', () => {
       storeReview({ repo: 'owner/repo', prNumber: 1, status: 'open' });
       storeReview({ repo: 'owner/repo', prNumber: 2, status: 'open' });
       updateReviewStatus('owner/repo', 1, 'merged');
-      expect(getReviews()[0].status).toBe('merged');
-      expect(getReviews()[1].status).toBe('open');
+      // getReviews() returns newest-first, so [0] is prNumber:2, [1] is prNumber:1
+      expect(getReviews()[0].status).toBe('open');
+      expect(getReviews()[1].status).toBe('merged');
     });
 
     it('does not update reviews for different repo', () => {
       storeReview({ repo: 'owner/repo-a', prNumber: 1, status: 'open' });
       storeReview({ repo: 'owner/repo-b', prNumber: 1, status: 'open' });
       updateReviewStatus('owner/repo-a', 1, 'closed');
-      expect(getReviews()[0].status).toBe('closed');
-      expect(getReviews()[1].status).toBe('open');
+      // getReviews() returns newest-first, so [0] is repo-b, [1] is repo-a
+      expect(getReviews()[0].status).toBe('open');
+      expect(getReviews()[1].status).toBe('closed');
     });
 
     it('returns 0 when no reviews match', () => {

--- a/src/ai-review.js
+++ b/src/ai-review.js
@@ -427,8 +427,28 @@ function storeReview(entry) {
   saveReviews();
 }
 
-function getReviews() {
-  return _reviews;
+function getReviews(opts = {}) {
+  const { limit, offset = 0 } = typeof opts === 'object' ? opts : {};
+  // Newest-first
+  const sorted = [..._reviews].reverse();
+  if (limit !== undefined && limit !== null) return sorted.slice(offset, offset + limit);
+  return sorted;
+}
+
+function getReviewStats() {
+  const now = Date.now();
+  const weekAgo = now - 7 * 24 * 60 * 60 * 1000;
+  let total = 0, approve = 0, minor = 0, major = 0, unknown = 0, thisWeek = 0, totalFindings = 0;
+  for (const r of _reviews) {
+    total++;
+    if (r.assessment === 'approve') approve++;
+    else if (r.assessment === 'minor') minor++;
+    else if (r.assessment === 'major') major++;
+    else unknown++;
+    if (r.timestamp && new Date(r.timestamp).getTime() > weekAgo) thisWeek++;
+    totalFindings += r.findings || 0;
+  }
+  return { total, approve, minor, major, unknown, thisWeek, avgFindings: total ? +(totalFindings / total).toFixed(1) : 0 };
 }
 
 /**
@@ -470,6 +490,7 @@ export {
   supersedePreviousReviews,
   storeReview,
   getReviews,
+  getReviewStats,
   updateReviewStatus,
   _reviewTimestamps,
   _resetReviews,

--- a/src/dashboard-client.js
+++ b/src/dashboard-client.js
@@ -77,8 +77,13 @@ function toggleInsightsView(showInsights) {
 }
 
 function toggleReviewDetail(id) {
-  var el = document.getElementById("review-detail-" + id);
-  if (el) el.classList.toggle("open");
+  // Close any previously open detail row (accordion)
+  var prev = document.querySelector('tr.review-detail-row[style*="table-row"]');
+  if (prev && prev.getAttribute("data-pair-of") !== id) {
+    prev.style.display = "none";
+  }
+  var el = document.querySelector('tr.review-detail-row[data-pair-of="' + id + '"]');
+  if (el) el.style.display = el.style.display === "table-row" ? "none" : "table-row";
 }
 
 function runCmd(cmd, resultId) {
@@ -137,6 +142,14 @@ document.body.addEventListener("click", function(e) {
     return;
   }
 
+  // ── Review table row click → expand detail ──
+  var reviewRow = e.target.closest("tr.review-row");
+  if (reviewRow && !e.target.closest("a")) {
+    var rid = reviewRow.getAttribute("data-review-id");
+    if (rid) toggleReviewDetail(rid);
+    return;
+  }
+
   // ── Table sorting ──
   var th = e.target.closest("th[data-sort]");
   if (!th) return;
@@ -144,7 +157,7 @@ document.body.addEventListener("click", function(e) {
   var idx = Array.from(th.parentElement.children).indexOf(th);
   var tbody = table.querySelector("tbody");
   if (!tbody) return;
-  var rows = Array.from(tbody.querySelectorAll("tr"));
+  var rows = Array.from(tbody.querySelectorAll("tr:not([data-pair-of])"));
   var asc = th.getAttribute("data-sort") !== "asc";
   th.parentElement.querySelectorAll("th[data-sort]").forEach(function(h) { h.setAttribute("data-sort",""); });
   th.setAttribute("data-sort", asc ? "asc" : "desc");
@@ -153,7 +166,15 @@ document.body.addEventListener("click", function(e) {
     var bt = (b.children[idx]||{}).textContent || "";
     return (asc ? 1 : -1) * at.localeCompare(bt, undefined, {numeric:true});
   });
-  rows.forEach(function(r) { tbody.appendChild(r); });
+  rows.forEach(function(r) {
+    tbody.appendChild(r);
+    // Re-pair detail row after its data row
+    var pairId = r.getAttribute("data-review-id");
+    if (pairId) {
+      var detail = tbody.querySelector('tr[data-pair-of="' + pairId + '"]');
+      if (detail) tbody.appendChild(detail);
+    }
+  });
 });
 
 // ── Table filtering ──
@@ -163,18 +184,15 @@ document.body.addEventListener("input", function(e) {
   var id = e.target.getAttribute("data-filter");
   var tbody = document.querySelector("#" + id + " tbody");
   if (!tbody) return;
-  Array.from(tbody.querySelectorAll("tr")).forEach(function(row) {
-    row.style.display = row.textContent.toLowerCase().indexOf(q) !== -1 ? "" : "none";
-  });
-});
-
-// ── Reviews filter ──
-document.body.addEventListener("input", function(e) {
-  if (e.target.id !== "reviews-filter") return;
-  var q = e.target.value.toLowerCase();
-  document.querySelectorAll(".review-entry").forEach(function(entry) {
-    var filterText = entry.getAttribute("data-review-filter") || "";
-    entry.style.display = filterText.toLowerCase().indexOf(q) !== -1 ? "" : "none";
+  Array.from(tbody.querySelectorAll("tr:not([data-pair-of])")).forEach(function(row) {
+    var match = row.textContent.toLowerCase().indexOf(q) !== -1;
+    row.style.display = match ? "" : "none";
+    // Cascade: hide/close paired detail row when data row is hidden
+    var pairId = row.getAttribute("data-review-id");
+    if (pairId) {
+      var detail = tbody.querySelector('tr[data-pair-of="' + pairId + '"]');
+      if (detail) detail.style.display = match ? detail.style.display : "none";
+    }
   });
 });
 

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -5,7 +5,7 @@ import { checkDependabotConfiguration, checkExistingDependabotConfig, fixDependa
 import { generateConfigurationReport } from './reporting.js';
 import { createAppAuth } from '@octokit/auth-app';
 import { Octokit } from '@octokit/rest';
-import { getReviews, reviewPullRequest } from './ai-review.js';
+import { getReviews, getReviewStats, reviewPullRequest } from './ai-review.js';
 
 // ── Cache ────────────────────────────────────────────────────────────
 const cache = { data: null, timestamp: 0 };
@@ -375,7 +375,7 @@ function renderIssuesPartial(data) {
 // ── AI Reviews partial ───────────────────────────────────────────────
 function renderReviewsPartial() {
   let reviews;
-  try { reviews = getReviews(15); } catch { reviews = []; }
+  try { reviews = getReviews({ limit: 15 }); } catch { reviews = []; }
   if (reviews.length === 0) {
     return '<div class="alert" style="color:var(--dim);background:var(--surface);border:1px solid var(--border)">No AI reviews yet. Reviews are triggered automatically on PR open/sync, or manually via <span style="color:var(--accent)">/review-pr</span> command.</div>';
   }
@@ -407,15 +407,108 @@ function renderReviewsPartial() {
 }
 
 // ── Full reviews partial (for dedicated Reviews tab) ─────────────────
-function renderReviewsFullPartial() {
-  let reviews;
-  try { reviews = getReviews(50); } catch { reviews = []; }
 
-  const reviewCount = reviews.length;
-  // Inject badge count update
-  const badgeScript = `<span data-metric="reviews" style="display:none">${reviewCount}</span>`;
+function reviewAssessmentBadge(a) {
+  if (a === 'approve') return badge('ok', 'approve');
+  if (a === 'minor') return badge('warn', 'minor');
+  if (a === 'major') return badge('err', 'major');
+  return badge('muted', 'no verdict');
+}
 
-  if (reviews.length === 0) {
+function reviewVerdictIcon(a) {
+  if (a === 'approve') return '<span class="verdict-icon verdict-approve">&#10003;</span>';
+  if (a === 'minor') return '<span class="verdict-icon verdict-minor">&#9888;</span>';
+  if (a === 'major') return '<span class="verdict-icon verdict-major">&#10007;</span>';
+  return '<span class="verdict-icon verdict-unknown">?</span>';
+}
+
+function renderReviewStatsBanner(stats) {
+  const cards = [
+    { label: 'Total', value: stats.total, cls: '' },
+    { label: 'Approved', value: stats.approve, cls: 'stat-green' },
+    { label: 'Minor', value: stats.minor, cls: 'stat-yellow' },
+    { label: 'Major', value: stats.major, cls: 'stat-red' },
+    { label: 'This Week', value: stats.thisWeek, cls: '' },
+    { label: 'Avg Findings', value: stats.avgFindings, cls: '' },
+  ];
+  const inner = cards.map(c =>
+    '<div class="stat-card' + (c.cls ? ' ' + c.cls : '') + '">' +
+      '<div class="stat-value">' + c.value + '</div>' +
+      '<div class="stat-label">' + c.label + '</div>' +
+    '</div>'
+  ).join('');
+  return '<div class="reviews-stats-banner">' + inner + '</div>';
+}
+
+function renderReviewRowPair(r) {
+  const id = esc(r.id || (r.repo + '-' + r.pr + '-' + r.timestamp));
+  const findingsTag = r.findings > 0
+    ? ' ' + badge(r.findings > 2 ? 'err' : 'warn', r.findings + ' finding' + (r.findings !== 1 ? 's' : ''))
+    : '';
+  const repoShort = (r.repo || '').split('/').pop();
+
+  const dataRow =
+    '<tr class="review-row" data-review-id="' + id + '">' +
+      '<td>' + reviewVerdictIcon(r.assessment) + '</td>' +
+      '<td>' + esc(repoShort) + '</td>' +
+      '<td><a href="' + esc(r.url || '#') + '" target="_blank">#' + r.pr + '</a></td>' +
+      '<td class="review-row-title">' + esc(r.title || '') + '</td>' +
+      '<td>' + reviewAssessmentBadge(r.assessment) + findingsTag + '</td>' +
+      '<td>' + (r.findings || 0) + '</td>' +
+      '<td>' + esc(r.author || '') + '</td>' +
+      '<td class="dim">' + esc(timeAgo(r.timestamp)) + '</td>' +
+    '</tr>';
+
+  const detailRow =
+    '<tr class="review-detail-row" data-pair-of="' + id + '" style="display:none">' +
+      '<td colspan="8">' +
+        '<div class="review-detail-inner">' +
+          '<div class="review-detail-summary"><strong>Summary:</strong> ' + esc(r.summary || 'No summary available') + '</div>' +
+          '<div class="review-detail-body">' + (r.body || '<em>No review body stored</em>') + '</div>' +
+          '<div class="review-detail-actions">' +
+            '<div class="review-retrigger">' +
+              '<input class="filter-input" id="review-instructions-' + esc(r.repo) + '-' + r.pr +
+                '" placeholder="extra instructions (e.g. focus on security)" style="flex:1" />' +
+              '<button class="cmd-btn" onclick="triggerReview(\'' + esc(r.repo) + '\',' + r.pr + ')">RE-REVIEW</button>' +
+            '</div>' +
+            '<div class="review-action-status" id="review-status-' + esc(r.repo) + '-' + r.pr + '"></div>' +
+          '</div>' +
+        '</div>' +
+      '</td>' +
+    '</tr>';
+
+  return dataRow + detailRow;
+}
+
+function renderReviewsTable(reviews) {
+  const headers =
+    '<thead><tr>' +
+      '<th data-sort="">V</th>' +
+      '<th data-sort="">Repo</th>' +
+      '<th data-sort="">PR</th>' +
+      '<th data-sort="">Title</th>' +
+      '<th data-sort="">Assessment</th>' +
+      '<th data-sort="">Findings</th>' +
+      '<th data-sort="">Author</th>' +
+      '<th data-sort="">Age</th>' +
+    '</tr></thead>';
+
+  const rows = reviews.map(renderReviewRowPair).join('');
+
+  return '<div class="table-wrap"><table id="reviews-table">' + headers + '<tbody>' + rows + '</tbody></table></div>';
+}
+
+function renderReviewsFullPartial(url) {
+  const params = new URL(url || 'http://x/', 'http://x').searchParams;
+  const limit = parseInt(params.get('limit')) || 25;
+  const offset = parseInt(params.get('offset')) || 0;
+
+  let stats;
+  try { stats = getReviewStats(); } catch { stats = { total: 0, approve: 0, minor: 0, major: 0, unknown: 0, thisWeek: 0, avgFindings: 0 }; }
+
+  const badgeScript = '<span data-metric="reviews" style="display:none">' + stats.total + '</span>';
+
+  if (stats.total === 0) {
     return badgeScript +
       '<div class="empty-state">' +
         '<div class="empty-icon">&#9776;</div>' +
@@ -425,62 +518,47 @@ function renderReviewsFullPartial() {
       '</div>';
   }
 
-  const assessmentBadge = (a) => {
-    if (a === 'approve') return badge('ok', 'approve');
-    if (a === 'minor') return badge('warn', 'minor');
-    if (a === 'major') return badge('err', 'major');
-    return badge('muted', 'no verdict');
-  };
+  let reviews;
+  try { reviews = getReviews({ limit, offset }); } catch { reviews = []; }
 
-  const assessmentIcon = (a) => {
-    if (a === 'approve') return '<span class="verdict-icon verdict-approve">&#10003;</span>';
-    if (a === 'minor') return '<span class="verdict-icon verdict-minor">&#9888;</span>';
-    if (a === 'major') return '<span class="verdict-icon verdict-major">&#10007;</span>';
-    return '<span class="verdict-icon verdict-unknown">?</span>';
-  };
+  const hasMore = (offset + limit) < stats.total;
+  const nextOffset = offset + limit;
+  const loadMoreBtn = hasMore
+    ? '<div class="reviews-load-more">' +
+        '<button class="cmd-btn-ghost" id="reviews-load-more-btn" ' +
+          'hx-get="/dashboard/partials/reviews-more?limit=' + limit + '&offset=' + nextOffset + '" ' +
+          'hx-target="#reviews-table tbody" hx-swap="beforeend" hx-indicator="#poll-indicator">' +
+          'Load more (' + (stats.total - nextOffset) + ' remaining)</button>' +
+      '</div>'
+    : '';
 
-  const rows = reviews.map(r => {
-    const findingsTag = r.findings > 0
-      ? ' ' + badge(r.findings > 2 ? 'err' : 'warn', r.findings + ' finding' + (r.findings !== 1 ? 's' : ''))
-      : '';
-    const id = esc(r.id || `${r.repo}-${r.pr}-${r.timestamp}`);
+  return badgeScript + renderReviewStatsBanner(stats) + renderReviewsTable(reviews) + loadMoreBtn;
+}
 
-    return '<div class="review-entry" data-review-filter="' + esc((r.repo || '') + ' ' + (r.title || '') + ' ' + (r.assessment || '') + ' ' + (r.author || '')) + '">' +
-      // Header row (always visible)
-      '<div class="review-entry-header" onclick="toggleReviewDetail(\'' + id + '\')">' +
-        assessmentIcon(r.assessment) +
-        '<div class="review-entry-info">' +
-          '<div class="review-entry-title">' +
-            '<a href="' + esc(r.url || '#') + '" target="_blank" onclick="event.stopPropagation()">' + esc(r.repo) + ' #' + r.pr + '</a> ' +
-            assessmentBadge(r.assessment) + findingsTag +
-          '</div>' +
-          '<div class="review-entry-subtitle">' + esc(r.title || '') + '</div>' +
-        '</div>' +
-        '<div class="review-entry-meta">' +
-          '<span class="dim">' + esc(r.model || '') + '</span>' +
-          '<span class="dim">' + esc(timeAgo(r.timestamp)) + ' ago</span>' +
-        '</div>' +
-        '<span class="review-chevron">&#9660;</span>' +
-      '</div>' +
-      // Detail (collapsed by default)
-      '<div class="review-detail" id="review-detail-' + id + '">' +
-        '<div class="review-detail-summary">' +
-          '<strong>Summary:</strong> ' + esc(r.summary || 'No summary available') +
-        '</div>' +
-        '<div class="review-detail-body">' + (r.body || '<em>No review body stored</em>') + '</div>' +
-        '<div class="review-detail-actions">' +
-          '<div class="review-retrigger">' +
-            '<input class="filter-input" id="review-instructions-' + esc(r.repo) + '-' + r.pr +
-              '" placeholder="extra instructions (e.g. focus on security)" style="flex:1" />' +
-            '<button class="cmd-btn" onclick="triggerReview(\'' + esc(r.repo) + '\',' + r.pr + ')">RE-REVIEW</button>' +
-          '</div>' +
-          '<div class="review-action-status" id="review-status-' + esc(r.repo) + '-' + r.pr + '"></div>' +
-        '</div>' +
-      '</div>' +
-    '</div>';
-  }).join('');
+function renderReviewsMorePartial(url) {
+  const params = new URL(url || 'http://x/', 'http://x').searchParams;
+  const limit = parseInt(params.get('limit')) || 25;
+  const offset = parseInt(params.get('offset')) || 0;
 
-  return badgeScript + rows;
+  let reviews, stats;
+  try { reviews = getReviews({ limit, offset }); } catch { reviews = []; }
+  try { stats = getReviewStats(); } catch { stats = { total: 0 }; }
+
+  const rows = reviews.map(renderReviewRowPair).join('');
+
+  const hasMore = (offset + limit) < stats.total;
+  const nextOffset = offset + limit;
+  // OOB swap to update the load-more button
+  const oobBtn = hasMore
+    ? '<div id="reviews-load-more-btn" hx-swap-oob="outerHTML" class="reviews-load-more">' +
+        '<button class="cmd-btn-ghost" id="reviews-load-more-btn" ' +
+          'hx-get="/dashboard/partials/reviews-more?limit=' + limit + '&offset=' + nextOffset + '" ' +
+          'hx-target="#reviews-table tbody" hx-swap="beforeend" hx-indicator="#poll-indicator">' +
+          'Load more (' + (stats.total - nextOffset) + ' remaining)</button>' +
+      '</div>'
+    : '<div id="reviews-load-more-btn" hx-swap-oob="outerHTML"></div>';
+
+  return rows + oobBtn;
 }
 
 // ── Static assets ────────────────────────────────────────────────────
@@ -684,6 +762,24 @@ th[data-sort="desc"]::after{content:" \\25BC";color:var(--accent)}
 .empty-text{font-size:0.8rem;line-height:1.6}
 .empty-text code{color:var(--accent);background:var(--surface);padding:0.1rem 0.3rem;border-radius:2px}
 
+/* ── Reviews stats banner ── */
+.reviews-stats-banner{display:grid;grid-template-columns:repeat(6,1fr);gap:0.5rem;margin-bottom:1rem}
+.reviews-stats-banner .stat-card{text-align:center;padding:0.6rem 0.4rem}
+.stat-green .stat-value{color:var(--green)}
+.stat-yellow .stat-value{color:var(--yellow)}
+.stat-red .stat-value{color:var(--red)}
+
+/* ── Reviews table ── */
+#reviews-table{width:100%}
+#reviews-table th{font-size:0.6rem;text-transform:uppercase;letter-spacing:0.08em;padding:0.4rem 0.5rem;cursor:pointer;user-select:none;white-space:nowrap}
+#reviews-table td{font-size:0.75rem;padding:0.45rem 0.5rem;vertical-align:middle}
+#reviews-table .review-row{cursor:pointer;transition:background .1s}
+#reviews-table .review-row:hover{background:var(--surface2)}
+.review-row-title{max-width:18rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.review-detail-row{background:var(--surface)}
+.review-detail-inner{padding:0.8rem}
+.reviews-load-more{text-align:center;padding:1rem 0}
+@media(max-width:768px){.reviews-stats-banner{grid-template-columns:repeat(3,1fr)}}
 
 /* ── Insights ── */
 .insights-toggle{display:flex;gap:0.35rem;align-items:center}
@@ -725,7 +821,7 @@ th[data-sort="desc"]::after{content:" \\25BC";color:var(--accent)}
 // ── Review Insights ──────────────────────────────────────────────────
 function computeReviewInsights() {
   let reviews;
-  try { reviews = getReviews(100); } catch { reviews = []; }
+  try { reviews = getReviews({ limit: 100 }); } catch { reviews = []; }
   if (!reviews.length) return null;
 
   const now = Date.now();
@@ -986,7 +1082,7 @@ function renderDashboardPage() {
             '<button class="active" onclick="toggleInsightsView(false)">Reviews</button>' +
             '<button onclick="toggleInsightsView(true)">Insights</button>' +
           '</div>' +
-          '<input class="filter-input" id="reviews-filter" placeholder="filter by repo, PR, assessment..." style="width:14rem" />' +
+          '<input class="filter-input" data-filter="reviews-table" placeholder="filter by repo, PR, assessment..." style="width:14rem" />' +
         '</div>' +
       '</div>' +
       '<div id="insights-section" style="display:none" hx-get="/dashboard/partials/insights" hx-trigger="load, insightsLoad" hx-swap="morph:innerHTML">' +
@@ -1152,8 +1248,14 @@ export function createDashboardHandler() {
 
     // AI Reviews full partial (for dedicated Reviews tab)
     if (req.method === 'GET' && path === '/dashboard/partials/reviews-full') {
-      try { sendHtml(res, 200, renderReviewsFullPartial()); }
+      try { sendHtml(res, 200, renderReviewsFullPartial(req.url)); }
       catch (err) { getLogger().error({err},'Dashboard reviews-full error'); sendHtml(res, 200, renderError(err)); }
+      return true;
+    }
+    // AI Reviews "load more" partial (appends rows)
+    if (req.method === 'GET' && path === '/dashboard/partials/reviews-more') {
+      try { sendHtml(res, 200, renderReviewsMorePartial(req.url)); }
+      catch (err) { getLogger().error({err},'Dashboard reviews-more error'); sendHtml(res, 200, renderError(err)); }
       return true;
     }
 


### PR DESCRIPTION
## Summary

- Replaces the flat card list in the AI Reviews tab with a stats banner, compact sortable/filterable table, and inline detail drawers
- `getReviews()` now accepts `{limit, offset}` options with newest-first ordering; new `getReviewStats()` aggregates totals in a single pass
- HTMX-powered "load more" pagination with OOB button updates for seamless row appending
- Table sort/filter properly excludes paired detail rows and re-pairs them after DOM reorder

## Test plan

- [x] `npx eslint` passes on all three source files
- [x] `npm test` — 626/626 tests pass (2 test expectations updated for newest-first ordering)
- [ ] Visual check: `http://localhost:3001/dashboard` → Reviews tab renders stats banner + table
- [ ] Click a row to expand detail drawer, click again to collapse
- [ ] Sort by each column header; detail rows stay paired
- [ ] Filter input narrows visible rows; hidden rows' details also hide
- [ ] "Load more" button appends next page of rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)