### PR TITLE
feat: config.local.yml override for deploy-safe config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ yarn-error.log*
 .env.development
 .env.test
 .env.production
+config.local.yml
 
 # Logs
 logs

--- a/__tests__/unit/config.test.js
+++ b/__tests__/unit/config.test.js
@@ -5,9 +5,43 @@ import {
   getRequiredSignaturesFlag,
   getDependabotLabels,
   getTargetIssueLabels,
+  deepMerge,
   _setConfigForTesting,
   DEFAULT_MERGE_SETTINGS
 } from '../../src/config.js';
+
+describe('deepMerge', () => {
+  it('merges top-level keys from both objects', () => {
+    const result = deepMerge({ a: 1 }, { b: 2 });
+    expect(result).toEqual({ a: 1, b: 2 });
+  });
+
+  it('overrides primitive values from source', () => {
+    const result = deepMerge({ a: 1, b: 'old' }, { b: 'new' });
+    expect(result).toEqual({ a: 1, b: 'new' });
+  });
+
+  it('recursively merges nested objects', () => {
+    const result = deepMerge(
+      { nested: { a: 1, b: 2 } },
+      { nested: { b: 3, c: 4 } }
+    );
+    expect(result).toEqual({ nested: { a: 1, b: 3, c: 4 } });
+  });
+
+  it('replaces arrays entirely from source', () => {
+    const result = deepMerge(
+      { items: [1, 2, 3] },
+      { items: [4, 5] }
+    );
+    expect(result).toEqual({ items: [4, 5] });
+  });
+
+  it('allows null to override a value', () => {
+    const result = deepMerge({ a: { b: 1 } }, { a: null });
+    expect(result).toEqual({ a: null });
+  });
+});
 
 describe('config', () => {
   afterEach(() => {

--- a/config.yml
+++ b/config.yml
@@ -62,6 +62,16 @@ dependabot_generation:
   default_labels: ["dependencies"]
   max_directories_per_ecosystem: 5
 
+ai_review:
+  enabled: false
+  endpoint: "http://localhost:11434/v1/chat/completions"
+  model: "qwen2.5-coder:3b"
+  max_diff_size: 12000
+  max_tokens: 2000
+  temperature: 0.3
+  timeout: 120000
+  allow_remote_endpoint: false
+
 scheduler:
   interval_minutes: 5
   max_tasks_per_tick: 5

--- a/src/config.js
+++ b/src/config.js
@@ -27,12 +27,45 @@ export const DEPENDABOT_LABEL_DEFAULTS = {
 };
 
 const CONFIG_PATH = path.join(__dirname, '..', 'config.yml');
+const LOCAL_CONFIG_PATH = path.join(__dirname, '..', 'config.local.yml');
 let config = {};
 let TARGET_SETTINGS = { ...DEFAULT_MERGE_SETTINGS };
+
+/**
+ * Deep-merge source into target. Objects merge recursively;
+ * arrays and primitives from source replace target values.
+ */
+export function deepMerge(target, source) {
+  const result = { ...target };
+  for (const key of Object.keys(source)) {
+    const srcVal = source[key];
+    const tgtVal = target[key];
+    if (
+      srcVal !== null &&
+      typeof srcVal === 'object' &&
+      !Array.isArray(srcVal) &&
+      tgtVal !== null &&
+      typeof tgtVal === 'object' &&
+      !Array.isArray(tgtVal)
+    ) {
+      result[key] = deepMerge(tgtVal, srcVal);
+    } else {
+      result[key] = srcVal;
+    }
+  }
+  return result;
+}
 
 export function loadConfig() {
   try {
     config = yaml.load(fs.readFileSync(CONFIG_PATH, 'utf8')) || {};
+
+    if (fs.existsSync(LOCAL_CONFIG_PATH)) {
+      const localConfig = yaml.load(fs.readFileSync(LOCAL_CONFIG_PATH, 'utf8')) || {};
+      config = deepMerge(config, localConfig);
+      getLogger().info('Merged local overrides from config.local.yml');
+    }
+
     TARGET_SETTINGS = config?.settings?.merge || { ...DEFAULT_MERGE_SETTINGS };
     const validation = validateConfig(config);
     if (!validation.valid) {


### PR DESCRIPTION
## Summary
- Adds gitignored `config.local.yml` that deep-merges on top of `config.yml` at startup
- Adds `ai_review` section to base config (disabled by default)
- Production server only needs `config.local.yml` with `ai_review.enabled: true` to survive `git reset --hard` deploys

## Test plan
- [x] `deepMerge` unit tests: top-level merge, primitive override, recursive nested, array replacement, null override
- [x] All 641 tests pass, eslint clean
- [ ] After merge: create `/opt/temper/config.local.yml` on server, `pm2 restart`, verify ai_review enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)