### PR TITLE
fix: dashboard stale data on browser refresh

### DIFF
--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -1272,8 +1272,8 @@ function renderDashboardPage() {
 }
 
 // ── Request handler ──────────────────────────────────────────────────
-function sendHtml(res, s, html) { res.writeHead(s, {'Content-Type':'text/html; charset=utf-8'}); res.end(html); }
-function sendJson(res, s, obj) { res.writeHead(s, {'Content-Type':'application/json'}); res.end(JSON.stringify(obj)); }
+function sendHtml(res, s, html) { res.writeHead(s, {'Content-Type':'text/html; charset=utf-8','Cache-Control':'no-store'}); res.end(html); }
+function sendJson(res, s, obj) { res.writeHead(s, {'Content-Type':'application/json','Cache-Control':'no-store'}); res.end(JSON.stringify(obj)); }
 function readBody(req) {
   return new Promise((resolve, reject) => {
     let data = '';


### PR DESCRIPTION
## Summary
- Add `Cache-Control: no-store` to `sendHtml()` and `sendJson()` in the dashboard handler
- Prevents browsers from caching HTMX partial responses (deployment panel, summary, repos, PRs, etc.)
- Fixes the issue where refreshing the page shows stale data (deployed SHA, "started X ago", branch count all frozen)

## Root cause
The `sendHtml` and `sendJson` helpers had no `Cache-Control` header, so browsers cached XHR responses from HTMX partials. On page reload, the browser served disk-cached HTML instead of hitting the server.

## Test plan
- [ ] Deploy and verify: refresh the dashboard — deployment SHA, "started ago", and branch count should update on each reload
- [ ] Verify HTMX polling still works (partials auto-refresh every 10 min)
- [ ] Static assets (htmx.js, idiomorph.js, app.js) still cache normally via their own max-age headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)