### PR TITLE
fix: require PR before merging to default branch

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -32,7 +32,8 @@ branch_protection:
       strict: true
       contexts: []
     enforce_admins: true
-    required_pull_request_reviews: null
+    required_pull_request_reviews:
+      required_approving_review_count: 0
     required_linear_history: false
     required_conversation_resolution: false
     restrictions: null


### PR DESCRIPTION
## Summary
- Change `required_pull_request_reviews` from `null` to `{ required_approving_review_count: 0 }`
- Blocks direct pushes to main — all changes must go through a PR
- Zero approvals required — sole developer can create and merge own PRs without deadlock

## How it works
- GitHub API treats any non-null `required_pull_request_reviews` object as "require a PR"
- `required_approving_review_count: 0` means no approvals needed
- `dismiss_stale_reviews` and `require_code_owner_reviews` default to `false`
- After deploy + next sync, all org repos will enforce this

## Test plan
- [ ] After merge & deploy, run `/sync-all-repos` to apply to all repos
- [ ] Verify direct push to main is blocked
- [ ] Verify PR merge works without approvals

🤖 Generated with [Claude Code](https://claude.com/claude-code)