### PR TITLE
fix: repo creation race condition + AI review timeouts

### DIFF
--- a/__tests__/integration/app.test.js
+++ b/__tests__/integration/app.test.js
@@ -144,6 +144,9 @@ function createMockOctokit() {
       updateComment: jest.fn().mockResolvedValue({}),
       deleteComment: jest.fn().mockResolvedValue({})
     },
+    repos: {
+      getBranch: jest.fn().mockResolvedValue({ data: { name: 'main' } })
+    },
     request: jest.fn().mockResolvedValue({ status: 200, data: {} })
   };
 }
@@ -159,6 +162,7 @@ function createRepoCreatedContext(overrides = {}) {
         full_name: 'pulseengine/test-repo',
         name: 'test-repo',
         has_issues: true,
+        default_branch: 'main',
         owner: { login: 'pulseengine' },
         ...(overrides.repository || {})
       },

--- a/config.yml
+++ b/config.yml
@@ -61,13 +61,13 @@ dependabot_generation:
   max_directories_per_ecosystem: 5
 
 ai_review:
-  enabled: false
+  enabled: true
   endpoint: "http://localhost:11434/v1/chat/completions"
   model: "qwen2.5-coder:3b"
   max_diff_size: 12000
   max_tokens: 2000
   temperature: 0.3
-  timeout: 120000
+  timeout: 300000
   allow_remote_endpoint: false
 
 scheduler:

--- a/src/ai-review.js
+++ b/src/ai-review.js
@@ -185,7 +185,7 @@ function buildReviewPrompt(prData, diff, files, maxDiffSize) {
 }
 
 async function callLocalAI(endpoint, model, systemPrompt, userPrompt, options = {}) {
-  const { maxTokens = 2000, temperature = 0.3, timeout = 120000 } = options;
+  const { maxTokens = 2000, temperature = 0.3, timeout = 300000 } = options;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeout);
@@ -201,7 +201,8 @@ async function callLocalAI(endpoint, model, systemPrompt, userPrompt, options = 
           { role: 'user', content: userPrompt }
         ],
         max_tokens: maxTokens,
-        temperature
+        temperature,
+        stream: false
       }),
       signal: controller.signal
     });

--- a/src/app.js
+++ b/src/app.js
@@ -115,20 +115,70 @@ function registerApp(app, { getRouter, addHandler } = {}) {
     if (repoOrg === targetOrg) {
       getLogger().info({ repo: repository.full_name }, 'New repository created');
 
+      // Wait for the default branch to exist before configuring.
+      // When GitHub fires repository.created, the repo exists but the default
+      // branch is only created after the first commit.
+      const defaultBranch = repository.default_branch || 'main';
+      const owner = repository.owner.login;
+      const repoName = repository.name;
+      let branchReady = false;
+
+      for (let attempt = 1; attempt <= 5; attempt++) {
+        try {
+          await context.octokit.repos.getBranch({
+            owner,
+            repo: repoName,
+            branch: defaultBranch
+          });
+          branchReady = true;
+          break;
+        } catch (err) {
+          if (err.status === 404) {
+            getLogger().info(
+              { repo: repository.full_name, branch: defaultBranch, attempt },
+              `Default branch not ready yet, retrying in 2s (attempt ${attempt}/5)`
+            );
+            await new Promise(resolve => setTimeout(resolve, 2000));
+          } else {
+            getLogger().warn(
+              { repo: repository.full_name, err: err.message },
+              'Unexpected error checking for default branch'
+            );
+            break;
+          }
+        }
+      }
+
+      if (!branchReady) {
+        getLogger().warn(
+          { repo: repository.full_name, branch: defaultBranch },
+          'Default branch never appeared — repo may still be empty. Skipping configuration.'
+        );
+        if (deliveryId) markProcessed(deliveryId);
+        return;
+      }
+
       const result = await configureRepository(context.octokit, repository, undefined, {
         enqueueTask: getEnqueueTask()
       });
 
       if (repository.has_issues) {
-        await context.octokit.issues.create({
-          owner: repository.owner.login,
-          repo: repository.name,
-          title: 'Repository Configuration',
-          body: result.success
-            ? '✅ This repository has been automatically configured with standard merge settings and branch protection.'
-            : `❌ Configuration failed: ${result.error}`,
-          labels: ['automation', 'configuration']
-        });
+        try {
+          await context.octokit.issues.create({
+            owner,
+            repo: repoName,
+            title: 'Repository Configuration',
+            body: result.success
+              ? '✅ This repository has been automatically configured with standard merge settings and branch protection.'
+              : `❌ Configuration failed: ${result.error}`,
+            labels: ['automation', 'configuration']
+          });
+        } catch (issueErr) {
+          getLogger().warn(
+            { repo: repository.full_name, err: issueErr.message },
+            'Failed to create configuration issue — issues may not be fully initialized yet'
+          );
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- **New repo race condition**: `repository.created` webhook fires before the default branch exists. Branch protection API returns 404, then issue creation crashes. Now polls up to 5 times (2s intervals) for the branch to appear, and wraps issue creation in try/catch.
- **AI review timeouts**: Ollama streams responses by default. Without `stream: false`, `response.json()` hangs reading SSE chunks until the AbortController fires after 120s. Added `stream: false` and bumped default timeout to 300s.
- **AI reviews enabled**: Flipped `ai_review.enabled` to `true` in config + updated server config.

## Root causes
1. GitHub fires `repository.created` before the repo has any commits/branches — the branch protection PUT returns 404
2. Ollama's `/v1/chat/completions` defaults to streaming SSE. The code called `response.json()` expecting a single JSON blob, but got chunked SSE data that never terminates cleanly

## Test plan
- [x] All 654 tests pass
- [ ] Create a new repo in the org — temper should wait for the branch and then configure it
- [ ] Open a non-bot PR — AI review should post within ~5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)