### PR TITLE
fix: apply dependabot config via PR (branch protection blocks direct push)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -63,6 +63,20 @@ controller_repo:
   # Reaction approvers must add to authorise provisioning.
   approval_reaction: "+1"
 
+# Configuration changes (dependabot.yml, templates, CODEOWNERS) are applied via
+# pull request rather than direct push. Required because branch protection
+# (PR #19) blocks direct commits to default branches.
+change_strategy:
+  use_pull_requests: true
+  pr_title: "[temper] Configuration update"
+  pr_body: |
+    Automated configuration update from the Temper bot.
+
+    Review the changes and merge if they match the org standard.
+  pr_labels:
+    - automation
+    - dependencies
+
 auto_merge:
   enabled: true
   on_dependabot: true

--- a/src/schema.js
+++ b/src/schema.js
@@ -140,6 +140,20 @@ export function validateConfig(config) {
     }
   }
 
+  if (config.change_strategy !== undefined) {
+    const cs = config.change_strategy;
+    if (typeof cs !== 'object' || cs === null) {
+      errors.push('change_strategy must be an object');
+    } else {
+      if (cs.use_pull_requests !== undefined && typeof cs.use_pull_requests !== 'boolean') {
+        errors.push('change_strategy.use_pull_requests must be a boolean');
+      }
+      if (cs.pr_labels !== undefined && !Array.isArray(cs.pr_labels)) {
+        errors.push('change_strategy.pr_labels must be an array');
+      }
+    }
+  }
+
   if (config.controller_repo !== undefined) {
     const cr = config.controller_repo;
     if (typeof cr !== 'object' || cr === null) {


### PR DESCRIPTION
## Root cause
After PR #19 added `required_pull_request_reviews` to the default branch, direct pushes from the bot are blocked. The scheduler — now actually running post-#21 — immediately revealed this: every `generate-dependabot` task across the org failed with:

> Could not create file: Changes must be made through a pull request

Three rows in the deployed task store (`pulseengine/temper`, `pulseengine/rivet`, `pulseengine/spar`) are stuck at `status=failed, attempts=3`.

## Fix
Set `change_strategy.use_pull_requests: true` in `config.yml`. The code path already exists in `src/dependabot.js:25-30` and `src/github-api.js:42-83` — it just wasn't enabled in config. Schema validation added.

## Manual cleanup after deploy
The 3 stuck rows have unique dedup keys, so new attempts won't re-enqueue. One-shot on netcup:

\`\`\`bash
node -e 'import(\"./src/task-store.js\").then(m => {
  const s = m.initTaskStore(\"./data/tasks.db\");
  s._db.prepare(\"DELETE FROM tasks WHERE status = ?\").run(\"failed\");
  s.close();
})'
\`\`\`

A `/retry-failed-tasks` ChatOps command is a sensible follow-up but out of scope here.

## Test plan
- [x] All 698 tests pass
- [x] eslint clean
- [ ] After merge + deploy + manual cleanup: next non-bot PR in any org repo → bot enqueues `generate-dependabot` → scheduler claims it → bot opens a \`[temper] Configuration update\` PR adding \`.github/dependabot.yml\`
- [ ] **AI review on this PR should fire** (PR #22 fixed the `octokit.issues` bug, deployed at \`a9b8e6f\`). If a review comment lands within ~5 min, both fixes are confirmed working.

## Risk & rollout
- Risk: **low**. Pure config flip. PR-creation path covered by integration tests.
- Rollout: self-update on merge, then one-shot cleanup of the 3 failed rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)