### PR TITLE
fix: emit dependabot.yml without YAML anchors

### DIFF
--- a/__tests__/integration/dependabot.test.js
+++ b/__tests__/integration/dependabot.test.js
@@ -80,7 +80,7 @@ describe('dependabot', () => {
         'owner',
         'repo',
         '.github/dependabot.yml',
-        yaml.dump(depConfig),
+        yaml.dump(depConfig, { noRefs: true }),
         'Add/Update Dependabot configuration'
       );
       expect(createConfigurationPR).not.toHaveBeenCalled();
@@ -96,10 +96,33 @@ describe('dependabot', () => {
         'owner',
         'repo',
         '.github/dependabot.yml',
-        yaml.dump(depConfig),
+        yaml.dump(depConfig, { noRefs: true }),
         'Add/Update Dependabot configuration'
       );
       expect(createConfigurationPR).not.toHaveBeenCalled();
+    });
+
+    it('emits dependabot.yml without YAML anchors even when labels are shared across updates', async () => {
+      // Regression: js-yaml's default dump deduplicates repeated structures with
+      // anchors (&ref_0 / *ref_0). GitHub's dependabot.yml parser rejects
+      // anchors. The fix is yaml.dump(cfg, { noRefs: true }).
+      const sharedLabels = ['dependencies'];
+      const sharedConfig = {
+        version: 2,
+        updates: [
+          { 'package-ecosystem': 'npm', directory: '/', schedule: { interval: 'weekly' }, labels: sharedLabels },
+          { 'package-ecosystem': 'docker', directory: '/', schedule: { interval: 'weekly' }, labels: sharedLabels }
+        ]
+      };
+      _setConfigForTesting({});
+
+      await applyDependabotConfig(octokit, 'owner', 'repo', sharedConfig);
+
+      const dumpedContent = upsertRepoFile.mock.calls[0][4];
+      expect(dumpedContent).not.toMatch(/&ref_/);
+      expect(dumpedContent).not.toMatch(/\*ref_/);
+      // Both updates should still carry the labels inline
+      expect(dumpedContent.match(/labels:/g) || []).toHaveLength(2);
     });
 
     it('applies config via PR when use_pull_requests is true', async () => {
@@ -114,7 +137,7 @@ describe('dependabot', () => {
         'owner',
         'repo',
         '.github/dependabot.yml',
-        yaml.dump(depConfig),
+        yaml.dump(depConfig, { noRefs: true }),
         'Update Dependabot configuration'
       );
       expect(upsertRepoFile).not.toHaveBeenCalled();

--- a/src/app.js
+++ b/src/app.js
@@ -462,7 +462,7 @@ function registerApp(app, options = {}) {
           const yaml = (await import('js-yaml')).default;
           let body = `## Generated Dependabot Configuration for ${owner}/${repo}\n\n`;
           body += `${result.report}\n\n`;
-          body += '```yaml\n' + yaml.dump(result.config) + '```\n\n';
+          body += '```yaml\n' + yaml.dump(result.config, { noRefs: true }) + '```\n\n';
           body += 'Applying configuration...';
 
           await context.octokit.issues.createComment({

--- a/src/dependabot.js
+++ b/src/dependabot.js
@@ -23,7 +23,10 @@ async function applyDependabotConfig(octokit, owner, repo, dependabotConfig) {
     getLogger().info(`Applying Dependabot configuration to ${owner}/${repo}`);
 
     const usePR = config.change_strategy?.use_pull_requests || false;
-    const yamlContent = yaml.dump(dependabotConfig);
+    // noRefs: true inlines repeated structures (e.g. shared `labels` arrays)
+    // instead of emitting YAML anchors (`&ref_0` / `*ref_0`) that GitHub's
+    // dependabot.yml parser rejects.
+    const yamlContent = yaml.dump(dependabotConfig, { noRefs: true });
 
     if (usePR) {
       await createConfigurationPR(


### PR DESCRIPTION
## Root cause
The bot-generated \`.github/dependabot.yml\` in PR #25 was rejected by GitHub's dependabot parser because \`js-yaml\`'s default \`dump()\` deduplicates the shared \`labels: ['dependencies']\` array using YAML anchors (\`&ref_0\` / \`*ref_0\`). Valid YAML, invalid dependabot.yml.

## Fix
Pass \`{ noRefs: true }\` to \`yaml.dump\` in:
- \`src/dependabot.js:26\` — the upsert/PR path that writes the file
- \`src/app.js:465\` — the \`/generate-dependabot\` ChatOps preview block

Regression test added: constructs a config with two updates sharing a labels array, asserts dumped output contains neither \`&ref_\` nor \`*ref_\`.

## Test plan
- [x] 753 tests pass (was 752, +1 regression)
- [x] eslint clean
- [ ] **After merge + self-update + close-and-reopen of #25**: bot's auto dependabot.yml passes the \`.github/dependabot.yml\` check.

## Risk & rollout
- Risk: **low**. Single serializer option. Semantically identical output.
- Rollout: self-update on merge, then close #25 so the bot regenerates clean on the next PR cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)