### PR TITLE
fix: rivet binary path resolution + drop fragile .issues guard

### DIFF
--- a/src/ai-review.js
+++ b/src/ai-review.js
@@ -382,6 +382,13 @@ async function reviewPullRequest(octokit, owner, repo, prNumber) {
     if (rivetCfg?.enabled && rivetCfg?.binary_path) {
       const headSha = prData.data.head?.sha;
       const baseSha = prData.data.base?.sha;
+      // Resolve binary path against the temper deploy root, NOT the tmpdir
+      // cwd that runRivetOracle uses. Without this, a relative binary_path
+      // like "data/rivet/rivet" gets looked up inside the freshly-extracted
+      // PR tarball — which obviously doesn't have the rivet binary in it.
+      const resolvedBinary = path.isAbsolute(rivetCfg.binary_path)
+        ? rivetCfg.binary_path
+        : path.resolve(__dirname, '..', rivetCfg.binary_path);
       try {
         if (headSha && (await hasRivetYaml(octokit, owner, repo, headSha))) {
           oracleSummary = await withTempRepoCheckout(
@@ -389,7 +396,7 @@ async function reviewPullRequest(octokit, owner, repo, prNumber) {
             owner,
             repo,
             headSha,
-            (repoPath) => runRivetOracle(rivetCfg.binary_path, repoPath, {
+            (repoPath) => runRivetOracle(resolvedBinary, repoPath, {
               baseRef: baseSha,
               timeout: rivetCfg.timeout_ms || 60000
             })

--- a/src/app.js
+++ b/src/app.js
@@ -276,7 +276,13 @@ function registerApp(app, options = {}) {
     const config = getConfig();
     const { comment, repository, sender } = context.payload;
 
-    if (!comment?.body || !context.octokit?.issues) {
+    // Only check that the body is present. We previously also gated on
+    // `context.octokit?.issues` being defined, but Probot v14 doesn't
+    // *always* expose the `.issues` namespace — and silently skipping every
+    // ChatOps command when it's missing is worse than letting individual
+    // calls fail loudly (which they don't, in practice — `octokit.request()`
+    // is always available and the existing call sites use it).
+    if (!comment?.body || !context.octokit) {
       return;
     }
 


### PR DESCRIPTION
## Two production bugs surfaced by today's live test

### Bug 1 — rivet binary looked up in the wrong cwd
Logs at 20:14:31 UTC: \`err: 'spawn data/rivet/rivet ENOENT'\`. \`runRivetOracle\` calls \`execFile(binary, args, { cwd: repoPath })\` where \`repoPath\` is the freshly-extracted PR tarball. A *relative* \`binary_path\` is resolved against THAT cwd, not the temper deploy root. Node looks for \`<tmpdir>/data/rivet/rivet\` instead of \`/opt/temper/data/rivet/rivet\`.

Fix: resolve a relative path against \`__dirname/..\` before passing to the oracle.

### Bug 3 — \`/review-pr\` silently swallowed
The \`issue_comment.created\` handler had:
\`\`\`js
if (!comment?.body || !context.octokit?.issues) return;
\`\`\`
Same Probot v14 issue as PR #22: \`context.octokit.issues\` is sometimes \`undefined\` for this event type. The guard then silently kills *every* ChatOps command. Today's \`/review-pr\` on rivet#213 and temper#28 hit this — webhook arrived, handler bailed in 1 ms, no log.

Fix: drop the \`.issues\` portion of the guard. Downstream calls that work today keep working; one that fails throws into \`onError\` instead of vanishing.

## Test plan
- [x] 766 tests pass, eslint clean
- [ ] **After merge + self-update**: comment \`/review-pr\` on rivet#213 — should see a "🔍 AI review in progress..." within seconds.
- [ ] Logs show \`rivet validate\` executing (no ENOENT). Oracle findings prepend the review.

## Risk & rollout
- Risk: **low**. Both changes are narrow. Guard removal restores the contract the rest of the chatops already depend on; binary-path resolve is additive (only fires for relative paths).
- Rollout: self-update on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)