### PR TITLE
docs: fix doc drift (deploy scripts, env vars, stale CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,36 +97,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## Migration Guide
+## Migration Notes
 
-### From 0.x to 1.0
+The project currently ships **probot ^14.2.4** and **@octokit/rest ^22.0.1**
+(see `package.json`). Earlier versions of this CHANGELOG carried a stale
+"install probot@^12, @octokit/rest@^19" instruction that no longer matches
+reality and has been removed.
 
-1. **Update package.json**
-   ```bash
-   npm install probot@^12.0.0 @octokit/rest@^19.0.0
-   ```
-
-2. **Update configuration**
-   ```yaml
-   # Update config.yml to match new format
-   ```
-
-3. **Review changes**
-   - New merge settings format
-   - Improved error handling
-   - Better logging
-
-### From 1.x to 2.0 (Future)
-
-1. **Update dependencies**
-   ```bash
-   npm install probot@^13.0.0 @octokit/rest@^20.0.0
-   ```
-
-2. **Review breaking changes**
-   - New configuration format
-   - Updated API endpoints
-   - New authentication method
+When a migration is actually needed for a future release, a `### From X.x
+to Y.0` block describing the concrete steps will be added here at the time
+of that release.
 
 ## Deprecation Policy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ gh repo delete pulseengine/test-repo --confirm
 
 ### Running Tests
 
-`npm test` runs 453 tests. See DEVELOPMENT.md for test structure details.
+`npm test` runs the full Jest suite (unit + integration + smoke + e2e). See DEVELOPMENT.md for test structure details.
 
 ## Documentation
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -227,10 +227,8 @@ Bazel targets:
 | `lint` | `eslint src/ index.js functions.js __tests__/` | Lint source and tests |
 | `build` | `bazel build //...` | Bazel build |
 | `bazel:test` | `bazel test //...` | Bazel test |
-| `deploy:heroku` | `git push heroku main` | Deploy to Heroku |
-| `deploy:docker` | `docker build && docker push` | Build and push Docker image |
-| `deploy:server` | `pm2 restart/start` | Deploy with PM2 |
-| `deploy:netcup` | `npm install --production` | Prepare for Netcup hosting |
+| `docker:build` | `docker build -t temper .` | Build the multi-stage Alpine image |
+| `setup` | `node scripts/setup.js` | Interactive bootstrap wizard (org, user, email) |
 
 ## Architecture
 

--- a/GITHUB_APP_SETUP.md
+++ b/GITHUB_APP_SETUP.md
@@ -48,7 +48,7 @@ Subscribe to these events:
 1. Click "Generate a private key" button
 2. A `.pem` file will download automatically
 3. **Save this file securely** - it cannot be retrieved again!
-4. Store the key in your `.env` file as `GITHUB_PRIVATE_KEY`
+4. Store the key in your `.env` file as `PRIVATE_KEY`
 
 ### Step 5: Install the App
 
@@ -68,9 +68,9 @@ cp .env.example .env
 Edit the `.env` file with your actual credentials:
 
 ```
-GITHUB_APP_ID=123456          # From GitHub App settings
-GITHUB_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----..."  # Contents of .pem file
-GITHUB_WEBHOOK_SECRET=your_webhook_secret_here  # From webhook setup
+APP_ID=123456          # From GitHub App settings
+PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----..."  # Contents of .pem file
+WEBHOOK_SECRET=your_webhook_secret_here  # From webhook setup
 PORT=3000
 ORGANIZATION=pulseengine
 ```
@@ -89,9 +89,9 @@ npm start
 ```bash
 docker build -t temper .
 docker run -p 3000:3000 \
-  -e GITHUB_APP_ID=your_app_id \
-  -e GITHUB_PRIVATE_KEY="$(cat private-key.pem)" \
-  -e GITHUB_WEBHOOK_SECRET=your_webhook_secret \
+  -e APP_ID=your_app_id \
+  -e PRIVATE_KEY="$(cat private-key.pem)" \
+  -e WEBHOOK_SECRET=your_webhook_secret \
   temper
 ```
 

--- a/README.md
+++ b/README.md
@@ -138,10 +138,9 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for the full development guide.
 
 ## Deployment
 
-- **Docker** — `npm run deploy:docker` builds and pushes a multi-stage Alpine image
-- **Heroku** — `npm run deploy:heroku` pushes to Heroku via git
-- **PM2** — `npm run deploy:server` starts or restarts the app under PM2
-- **Netcup** — `npm run deploy:netcup` installs production dependencies for shared hosting
+- **Docker** — `npm run docker:build` builds the multi-stage Alpine image; push and run via your registry/orchestrator of choice.
+- **PM2** — production runs under PM2 (`pm2 start npm --name temper -- start`); self-update is wired so a push to `main` redeploys via the binary in `tools/self-update/`.
+- **Netcup VPS** — current production target. Single host, 3.8 GB RAM, no swap; see `verify-netcup-deployment.sh` for the post-install checks.
 
 ## License
 


### PR DESCRIPTION
Fixes Bugs #17, #18, #32 from `docs/agent-fleet/bugs.md` (wave-1 Junior dev + Documentation reviewer).

- README/DEVELOPMENT: drop four fictional `npm run deploy:*` scripts; replace with what actually exists.
- GITHUB_APP_SETUP.md: `GITHUB_*` legacy env var names → canonical `APP_ID`/`PRIVATE_KEY`/`WEBHOOK_SECRET`.
- CHANGELOG.md: drop the misleading 'install probot@^12, @octokit/rest@^19' migration block.
- CONTRIBUTING.md: drop the hard-coded `453 tests` magic number.

(Bug #31 was a false positive — `CODE_OF_CONDUCT.md` actually exists.)

- [x] 806 tests pass (no source changes)
- [x] eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)