### PR TITLE
chore: hygiene cluster — LICENSE + audit-fail + enforcing verify-netcup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - run: npm ci
       - run: npm test -- --coverage
       - name: Security audit
-        run: npm audit --audit-level=moderate || true
+        run: npm audit --audit-level=moderate
       - name: Upload coverage
         if: always()
         uses: actions/upload-artifact@v4

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 PulseEngine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/verify-netcup-deployment.sh
+++ b/verify-netcup-deployment.sh
@@ -1,79 +1,60 @@
 #!/bin/bash
+# Netcup deployment verification.
+#
+# Each check exits non-zero on failure so this script can be wired into a
+# post-deploy hook. (Wave-1 DevOps agent flagged the previous all-`echo`
+# version as performative, Bug #33 in `docs/agent-fleet/bugs.md`.)
+#
+# Run from the deploy directory (`/opt/temper` on netcup) AFTER `npm ci
+# --production`.
 
-echo "🔍 Netcup Deployment Verification Script"
-echo "========================================"
-echo ""
+set -euo pipefail
 
-# Check if running on Netcup
-echo "📋 Checking environment..."
-if [ -f "/etc/netcup-hosting" ]; then
-    echo "✅ Netcup environment detected"
-else
-    echo "ℹ️  Not running on Netcup (or detection failed)"
-fi
+fail() { echo "❌ $*"; exit 1; }
+ok()   { echo "✅ $*"; }
 
-echo ""
-echo "📁 Checking file structure..."
-if [ -f "index.js" ] && [ -f "package.json" ] && [ -f "config.yml" ]; then
-    echo "✅ All required files present"
-else
-    echo "❌ Missing required files"
-    exit 1
-fi
+echo "🔍 Netcup Deployment Verification"
+echo "================================="
 
 echo ""
-echo "📦 Checking Node.js dependencies..."
-if [ -d "node_modules" ]; then
-    echo "✅ node_modules directory exists"
-else
-    echo "⚠️  node_modules missing - run 'npm install --production'"
-fi
+echo "📁 File structure"
+[ -f index.js ] && [ -f package.json ] && [ -f config.yml ] \
+  || fail "missing one of: index.js / package.json / config.yml"
+ok "core files present"
 
 echo ""
-echo "🔐 Checking environment variables..."
-if [ -f ".env" ]; then
-    echo "✅ .env file exists"
-    # Check for required variables
-    if grep -q "GITHUB_APP_ID" .env && grep -q "GITHUB_PRIVATE_KEY" .env && grep -q "GITHUB_WEBHOOK_SECRET" .env; then
-        echo "✅ All required environment variables present"
-    else
-        echo "❌ Missing required environment variables in .env"
+echo "📦 Dependencies"
+[ -d node_modules ] || fail "node_modules missing — run 'npm ci --production'"
+ok "node_modules present"
+
+echo ""
+echo "🔐 Environment file"
+[ -f .env ] || fail ".env missing"
+for var in APP_ID PRIVATE_KEY WEBHOOK_SECRET; do
+  if ! grep -qE "^${var}=" .env; then
+    # Accept legacy GITHUB_-prefixed names (mapped at runtime).
+    if ! grep -qE "^GITHUB_${var}=" .env; then
+      fail ".env missing required variable: ${var} (or GITHUB_${var})"
     fi
+  fi
+done
+# WEBHOOK_SECRET cannot be empty or the literal "development".
+secret=$(grep -E '^(GITHUB_)?WEBHOOK_SECRET=' .env | head -1 | cut -d= -f2-)
+[ -n "$secret" ] || fail "WEBHOOK_SECRET is empty"
+[ "$secret" != "development" ] || fail "WEBHOOK_SECRET cannot be the literal 'development'"
+ok "required env vars present and non-default"
+
+echo ""
+echo "🌐 Reverse proxy"
+if [ -f .htaccess ]; then
+  grep -q "RewriteRule" .htaccess && grep -q "localhost:3000" .htaccess \
+    || fail ".htaccess present but missing RewriteRule → localhost:3000"
+  ok ".htaccess proxy configured"
 else
-    echo "❌ .env file missing"
+  echo "ℹ️  no .htaccess (skip if not using Apache)"
 fi
 
 echo ""
-echo "📄 Checking .htaccess configuration..."
-if [ -f ".htaccess" ]; then
-    echo "✅ .htaccess file exists"
-    if grep -q "RewriteRule" .htaccess && grep -q "localhost:3000" .htaccess; then
-        echo "✅ Proxy rules configured"
-    else
-        echo "⚠️  Proxy rules may be missing"
-    fi
-else
-    echo "⚠️  .htaccess file missing - create for Apache proxy"
-fi
-
-echo ""
-echo "🌐 Checking domain configuration..."
-echo "Please ensure:"
-echo "  - Domain points to your Netcup server"
-echo "  - SSL certificate is installed"
-echo "  - Webhook URL is set to https://your-domain.com/"
-
-echo ""
-echo "🚀 Ready for deployment!"
-echo ""
-echo "To start the application:"
-echo "  node index.js &"
-echo ""
-echo "To test the endpoints:"
-echo "  curl https://your-domain.com/health"
-echo "  curl https://your-domain.com/webhook"
-echo ""
-echo "For troubleshooting, check:"
-echo "  - Netcup error logs in control panel"
-echo "  - Node.js console output"
-echo "  - Apache access/error logs"
+echo "✅ Verification complete. Start the bot:"
+echo "    pm2 start npm --name temper -- start"
+echo "    curl http://localhost:3000/health"


### PR DESCRIPTION
Three small wave-1 fixes:
- **Bug #34**: `LICENSE` added at repo root (MIT, matches `package.json`).
- **Bug #23**: drop `|| true` from `npm audit` step in CI — moderate findings now fail the build.
- **Bug #33**: `verify-netcup-deployment.sh` rewritten to be enforcing (set -e, fail/ok helpers, env-var + secret check).

- [x] 834 tests pass
- [x] eslint clean
- [x] bash -n clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)