### PR TITLE
fix: sweep last context.octokit.repos.getBranch in app.js to .request() form

### DIFF
--- a/__tests__/integration/app.test.js
+++ b/__tests__/integration/app.test.js
@@ -148,11 +148,18 @@ function createMockOctokit() {
   const issuesUpdateComment = jest.fn().mockResolvedValue({});
   const issuesDeleteComment = jest.fn().mockResolvedValue({});
 
+  // Production now uses `.request()` for `repos.getBranch` too (PR fixing
+  // Bug #16 — `app.js:268` was on `context.octokit.repos.getBranch` which
+  // shares the PR-#22 failure mode). Route GET branches into a namespaced
+  // mock so existing `octokit.repos.getBranch.mockX` test calls still work.
+  const reposGetBranch = jest.fn().mockResolvedValue({ data: { name: 'main' } });
+
   const routeDispatch = {
     'POST /repos/{owner}/{repo}/issues': issuesCreate,
     'POST /repos/{owner}/{repo}/issues/{issue_number}/comments': issuesCreateComment,
     'PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}': issuesUpdateComment,
-    'DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}': issuesDeleteComment
+    'DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}': issuesDeleteComment,
+    'GET /repos/{owner}/{repo}/branches/{branch}': reposGetBranch
   };
 
   const request = jest.fn((route, params) => {
@@ -169,7 +176,7 @@ function createMockOctokit() {
       deleteComment: issuesDeleteComment
     },
     repos: {
-      getBranch: jest.fn().mockResolvedValue({ data: { name: 'main' } })
+      getBranch: reposGetBranch
     },
     request
   };

--- a/src/app.js
+++ b/src/app.js
@@ -265,11 +265,13 @@ function registerApp(app, options = {}) {
 
       for (let attempt = 1; attempt <= 3; attempt++) {
         try {
-          await context.octokit.repos.getBranch({
-            owner,
-            repo: repoName,
-            branch: defaultBranch
-          });
+          // Use .request() form rather than .repos.getBranch — Probot v14's
+          // `context.octokit.repos` namespace is unreliable on this event
+          // type (same root cause as PRs #22 / #29 / #30 for `.issues.X`).
+          await context.octokit.request(
+            'GET /repos/{owner}/{repo}/branches/{branch}',
+            { owner, repo: repoName, branch: defaultBranch }
+          );
           branchReady = true;
           break;
         } catch (err) {


### PR DESCRIPTION
Fixes Bug #16 from `docs/agent-fleet/bugs.md` (wave-1 Probot/Octokit expert).

`src/app.js:268` was the one remaining `context.octokit.repos.getBranch` call — same Probot-v14 namespace failure mode as PRs #22/#29/#30. Swept to `.request()` form. Test mock retrofitted so existing assertions on `repos.getBranch.mockX` keep working via route dispatch.

(`dashboard.js` is intentionally not touched — it uses its own `@octokit/rest` client where namespaces are reliable.)

- [x] 834 tests pass
- [x] eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)