### PR TITLE
fix: idempotency guard on pull_request.opened (Bug #13)

### DIFF
--- a/__tests__/integration/app.test.js
+++ b/__tests__/integration/app.test.js
@@ -695,6 +695,54 @@ describe('app', () => {
 
       expect(getLogger().error).toHaveBeenCalledWith({ err: error }, 'Probot error');
     });
+
+    // Bug #13: pull_request.opened must dedupe on deliveryId. Without
+    // this, Probot retries replay enablePullRequestAutoMerge, the AI
+    // review (only the AI side has its own 5-min throttle), and the
+    // dependabot enqueue.
+    it('pull_request.opened skips duplicate webhook deliveries', async () => {
+      isProcessed.mockReturnValue(true);
+      _setConfigForTesting({ ai_review: { enabled: true } });
+      reviewPullRequest.mockClear();
+      const { handlers } = setupApp();
+
+      const context = {
+        id: 'delivery-pr-opened-dup',
+        log: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+        octokit: createMockOctokit(),
+        payload: {
+          pull_request: { number: 7, node_id: 'PR_7' },
+          repository: { name: 'rivet', owner: { login: 'pulseengine' }, default_branch: 'main' },
+          sender: { login: 'human' }
+        }
+      };
+
+      await handlers['pull_request.opened'](context);
+
+      expect(reviewPullRequest).not.toHaveBeenCalled();
+      expect(markProcessed).not.toHaveBeenCalled();
+    });
+
+    it('pull_request.opened marks delivery processed on completion', async () => {
+      _setConfigForTesting({ ai_review: { enabled: true } });
+      reviewPullRequest.mockResolvedValue({ success: true });
+      const { handlers } = setupApp();
+
+      const context = {
+        id: 'delivery-pr-opened-1',
+        log: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+        octokit: createMockOctokit(),
+        payload: {
+          pull_request: { number: 8, node_id: 'PR_8' },
+          repository: { name: 'rivet', owner: { login: 'pulseengine' }, default_branch: 'main' },
+          sender: { login: 'human' }
+        }
+      };
+
+      await handlers['pull_request.opened'](context);
+
+      expect(markProcessed).toHaveBeenCalledWith('delivery-pr-opened-1');
+    });
   });
 
   // =========================================================================

--- a/src/app.js
+++ b/src/app.js
@@ -839,6 +839,18 @@ function registerApp(app, options = {}) {
   // PR opened: auto-merge for bots, AI review, dependabot generation check
   app.on('pull_request.opened', async (context) => {
     if (context.log) setLogger(context.log);
+    // Bug #13: dedupe at handler entry. Without this guard, a Probot
+    // webhook redelivery (~5 retries on 5xx/timeout) re-runs auto-merge
+    // enable, the AI review, and the dependabot enqueue. The 5-min
+    // _reviewTimestamps throttle in reviewPullRequest only catches the
+    // AI review path; it doesn't protect enablePullRequestAutoMerge or
+    // the task-store enqueue.
+    const deliveryId = context.id;
+    if (deliveryId && isProcessed(deliveryId)) {
+      getLogger().info({ deliveryId }, 'Skipping duplicate pull_request.opened delivery');
+      return;
+    }
+
     const config = getConfig();
     const pr = context.payload.pull_request;
     const { repository } = context.payload;
@@ -926,6 +938,8 @@ function registerApp(app, options = {}) {
         }
       }
     }
+
+    if (deliveryId) markProcessed(deliveryId);
   });
 
   app.on('pull_request.closed', async (context) => {


### PR DESCRIPTION
## Summary
- Adds the standard \`isProcessed\`/\`markProcessed\` dedupe pattern to \`pull_request.opened\`.
- Closes Bug #13 from \`docs/agent-fleet/bugs.md\`.

## Why
Without this, Probot's webhook retry (~5 attempts on 5xx/timeout) replays \`enablePullRequestAutoMerge\` (spammy), the AI review (only catches retries within the 5-min \`_reviewTimestamps\` window), and the dependabot enqueue (creates duplicate task-store entries with the same key).

## Test plan
- [x] 2 new tests covering the dup-skip and mark-on-success paths
- [x] \`npm test\` → 836 pass (was 834)
- [x] \`npm run lint\` → clean

## Follow-up
\`pull_request.synchronize\` and \`.reopened\` (added in PR #50) need the same guard. Folding that in once #50 lands rather than producing a merge conflict here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)