### PR TITLE
config: require Format/Clippy/Test as org-wide branch-protection floor

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -30,7 +30,17 @@ branch_protection:
   default:
     required_status_checks:
       strict: true
-      contexts: []
+      # Universal floor: every pulseengine Rust repo has these three
+      # jobs in its CI workflow. Per-repo can extend (e.g. spar adds
+      # Test, Cargo Deny, Mutation Testing, etc. via repo-level
+      # branch protection — those settings stack with this floor).
+      # Bumping this list to require something that not every repo
+      # ships will leave those repos unable to merge, so keep it
+      # minimal and additive.
+      contexts:
+        - Format
+        - Clippy
+        - Test
     enforce_admins: true
     required_pull_request_reviews:
       required_approving_review_count: 0


### PR DESCRIPTION
## Summary

Currently `branch_protection.default.required_status_checks.contexts`
is empty, so temper applies branch protection to every pulseengine
repo but doesn't gate merges on any specific CI outcome. This PR
adds a minimal universal floor: `Format`, `Clippy`, `Test` — three
job names that every pulseengine Rust repo defines in its CI workflow.

## Why minimal + additive

- Bumping this list to require something not every repo ships
  (e.g. `Mutation Testing`, `Cargo Deny`, `Security Audit`) would
  leave those repos stuck in unmergeable state because the required
  check would never appear on their PRs.
- Per-repo branch protection extends this floor without conflict.
  spar's main branch already requires the full 13-job set via
  direct API config (added during the smithy migration); those
  repo-level settings stack on top of this temper-managed floor.

## Effect after merge

Temper's next sweep applies the new floor to all 27 pulseengine
repos. From that point on, any PR to a default branch must show
green Format / Clippy / Test before the merge button enables.

## Test plan

- [ ] Temper config validation passes (whatever check the project runs)
- [ ] Manually verify on one quiet repo that next branch-protection
      sweep includes the three contexts
- [ ] Confirm spar's existing 13-context list is preserved (additive,
      not replaced)

## Followups (not this PR)

- Open issues for two temper features still UI-only:
  - org-level Actions "fork PR approval policy"
  - org-level "allowed actions" allowlist